### PR TITLE
Bump to 0.18, removing the dependency on html

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.1",
+    "version": "2.0.2",
     "summary": "an experimental library for working with records",
     "repository": "https://github.com/evancz/focus.git",
     "license": "BSD3",
@@ -10,8 +10,7 @@
         "Focus"
     ],
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "elm-lang/html": "1.0.0 <= v < 2.0.0"
+        "elm-lang/core": "4.0.0 <= v < 6.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.17.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
The dependency on `html` was probably introduced to make the example run and slipped in with the last commit, so I took the freedom to remove it.